### PR TITLE
Fix some potential future issues with enums

### DIFF
--- a/chatterstorm_engine/src/tokens/object_type.rs
+++ b/chatterstorm_engine/src/tokens/object_type.rs
@@ -1,4 +1,5 @@
 #[repr(u8)]
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ObjectType {
     // Permanents

--- a/chatterstorm_engine/src/tokens/object_type.rs
+++ b/chatterstorm_engine/src/tokens/object_type.rs
@@ -1,3 +1,4 @@
+#[repr(u8)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ObjectType {
     // Permanents

--- a/chatterstorm_engine/src/tokens/subtype.rs
+++ b/chatterstorm_engine/src/tokens/subtype.rs
@@ -1,3 +1,4 @@
+#[repr(u16)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Subtype {
     // Artifact

--- a/chatterstorm_engine/src/tokens/subtype.rs
+++ b/chatterstorm_engine/src/tokens/subtype.rs
@@ -1,4 +1,5 @@
 #[repr(u16)]
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Subtype {
     // Artifact

--- a/chatterstorm_engine/src/tokens/supertype.rs
+++ b/chatterstorm_engine/src/tokens/supertype.rs
@@ -1,3 +1,4 @@
+#[repr(u8)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Supertype {
     // Official

--- a/chatterstorm_engine/src/tokens/supertype.rs
+++ b/chatterstorm_engine/src/tokens/supertype.rs
@@ -1,4 +1,5 @@
 #[repr(u8)]
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Supertype {
     // Official


### PR DESCRIPTION
Without `#[repr(u<...>)`, the transmute is a bit iffy. Also better to mark these as non-exhaustive (just in case someone thinks somewhere down the road that the number of card types or supertypes can't change).